### PR TITLE
fix list hover

### DIFF
--- a/src/components/Funnel/List/dnd.js
+++ b/src/components/Funnel/List/dnd.js
@@ -39,7 +39,7 @@ const hover = {
         target.index = Math.max(props.list.items.length-1, 0);
       }
 
-      if (item.list !== target.list || item.index !== target.index) {
+      if (item.list !== target.list) {
         props.moveCard(item, target);
       }
     }
@@ -57,7 +57,7 @@ const hover = {
 const dropTarget = {
   collect(connect) {
     return {
-      connectDropTarget: connect.dropTarget(),
+      connectDropTarget: connect.dropTarget()
     };
   },
 


### PR DESCRIPTION
@gnapse the issue w/ the example is that there's a double `hover` got triggered (1 in `Card`, 1 in List) so I think you shouldn't trigger `moveCards` in list `hover` when it's the same list cause the `Card` hover already handles that case
